### PR TITLE
Escape angle brackets

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -77,7 +77,7 @@
             <div class="section">
                 <h3>
     <a id="howToUse" class="anchor" href="#howToUse" aria-hidden="true"><span class="octicon octicon-link"></span></a>How to use angular-flash?</h3>
-                <p>Add the Following code to the <head> of your document.</p>
+                <p>Add the Following code to the &lt;head&gt; of your document.</p>
                 <pre class="prettyprint linenums">
 &lt;link type="text/css" rel="stylesheet" href="css/angular-flash.min.css" /&gt;
 // If you are using bootstrap v3 no need to include angular-flash.css


### PR DESCRIPTION
The word "head" was missing from the demo/index.html on how to use angular-flash because they weren't being escaped.

Before:
![capture](https://cloud.githubusercontent.com/assets/9600190/10212579/4c7b8d8c-67cf-11e5-9f62-399052292fb0.PNG)
