### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ myApp.controller('demoCtrl', ['Flash', function(Flash) {
     }
 }]);
 ```
-####Flash types####
+#### Flash types ####
 + success
 + info
 + warning


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
